### PR TITLE
feat: CLHS style message output and multi-line blocks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,8 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 25.1
-          - 25.3
-          - 26.1
-          - 26.3
+          - 27.2
+          - 28.1
           - snapshot
     steps:
     - uses: purcell/setup-emacs@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,5 @@ jobs:
         version: ${{ matrix.emacs_version }}
 
     - uses: actions/checkout@v1
-    - name: Byte compile
-      run: emacs -Q --batch -L . --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile doctest.el
-    - name: Try doctest-batch-check-feature
-      run: emacs -Q --batch -L . -l doctest f doctest-batch-check-feature doctest
+    - name: Run tests
+      run: ./run-tests.sh

--- a/README.md
+++ b/README.md
@@ -11,52 +11,58 @@ For example, with this Emacs Lisp file, `M-x doctest-check-feature foo` will che
   "Add X to Y.
 
   (foo-add 1 2)
-  ;; => 3"
+  => 3"
   (+ x y))
 
 (provide 'foo)
 ```
 
-## How to write tests?
+You can also test for message output:
+
+```emacs-lisp
+;;; foo.el --- Foo  -*- lexical-binding: t; -*-
+
+(defun foo-say (temp)
+  "Talk about the weather
+
+  (foo-say 'cold)
+  -> It’s cold outside
+  => brr
+
+  (foo-say 'hot)
+  -> It’s hot today
+  -> ... very hot!
+  => pfew
+  "
+  (pcase temp
+    ('cold (message "It's cold outside") 'brr)
+    ('hot (message "It's hot today") (message "... very hot!") 'pfew)))
+
+(provide 'foo)
+```
+
+Note the apostrophe (`’`) versus quote (`'`): that’s intentional. Emacs’
+`message` function transforms quotes to apostrophes.
+
+## Syntax
 
 Use this format:
 
-    (func arg1 arg2 ...)
-    ;; => RESULT
-
-The test is considered if two adjacent lines matches the regexp:
-
-``` emacs-lisp
-;; first line matches
-(rx bol (* space) "(")
-;; second line matches
-(rx bol (* space) ";; => ")
+```
+(my-func arg1 arg2 ...)
+-> message output (optional)
+=> RESULT
 ```
 
-Unfortunately, we can't (or shouldn't) put `(` at the beginning of a line (see
-the following quote), and because I don't like `\(`, doctest.el recognizes
-whitespaces before `(`, not `\`.
+All functions must exist in a file that provides a feature.
 
-> If a line in a documentation string begins with an
-> open-parenthesis, write a backslash before the open-parenthesis,
-> like this:
->
->      The argument FOO can be either a number
->      \(a buffer position) or a string (a file name).
->
-> This prevents the open-parenthesis from being treated as the start
-> of a defun (*note Defuns: (emacs)Defuns.).
->
->
-> [(elisp) Documentation Tips](https://www.gnu.org/software/emacs/manual/html_node/elisp/Documentation-Tips.html)
+## Running Tests
 
-## How to run tests?
-
-### Run tests interactively
+### Interactively
 
 use `M-x doctest-check-feature FEATURE` to check functions defined in `FEATURE`.
 
-### Run tests in batch mode
+### In Batch Mode
 
 Use `doctest-batch-check-feature`, e.g., to check features `foo` and `bar`
 

--- a/doctest.el
+++ b/doctest.el
@@ -34,46 +34,54 @@
 (defun doctest--length (lst)
   "Return the length of list LST.
 
-  (doctest--length '())
-  ;; => 0
+(doctest--length '())
+=> 0
 
-  (doctest--length '(a))
-  ;; => 1
+(doctest--length '(a))
+=> 1
 
-  (doctest--length '(a b))
-  ;; => 2
+(doctest--length '(a b))
+=> 2
 "
   (length lst))
 
 (defun doctest--eval (expr)
-  (let* ((err nil)
-         (got (condition-case e
-                  (eval expr 'lexical)
-                (error (setq err e)))))
-    (list err got)))
+  (condition-case e
+      (list nil (eval (read-from-string expr) 'lexical))
+    (error (list e nil))))
+
+(defvar doctest--rex
+  (let ((sexp-line (rx bol "(" (* not-newline) ")" eol)))
+    (rx (group-n 1 (regexp sexp-line)
+                   (* "\n" (regexp sexp-line)))
+        (? "\n" (* " ") "->" (* " ") (group-n 2 (* not-newline)))
+        "\n" (* " ") "=>" (* " ") (group-n 3 (* not-newline))))
+  "Regular expression to match a doctest, including potential message output")
+
+(defun doctest--next-doctest ()
+  (when (search-forward-regexp doctest--rex nil t)
+    (mapcar (lambda (group)
+              ((match-string-no-properties '(1 2 3))))
+
+(defun doctest--collect-while-true (f)
+  "Call function F and collect its results while it returns a non-NIL value"
+  (cl-loop for x = (funcall f) while x collect x))
+
+(defun doctest--docstring-tests (docstring)
+  "Return tests in this DOCSTRING."
+  (with-temp-buffer
+    (insert docstring)
+    (goto-char (point-min))
+    (save-excursion
+      (save-match-data
+        (doctest--collect-while-true 'doctest--next-doctest)))))
 
 (defun doctest--function-tests (function)
   "Return tests in FUNCTION's docstring."
-  (let* ((docstring (documentation function 'raw))
-         (lines (and docstring (split-string docstring "\n" t)))
-         (i 0)
-         tests)
-    (while (< i (1- (length lines)))
-      (let ((line-1 (nth i lines))
-            (line-2 (nth (1+ i) lines)))
-        (cond
-         ((and (string-match (rx bol (* space) "(") line-1)
-               (string-match (rx bol (* space) ";; => ") line-2))
-          (push (cons
-                 ;; XXX handle read error?
-                 (read line-1)
-                 (read
-                  (substring line-2 (length (match-string 0 line-2)))))
-                tests)
-          (cl-incf i 2))
-         (t
-          (cl-incf i 1)))))
-    (nreverse tests)))
+  ;; this is dash’s -some-> in a nutshell
+  (let ((docstr (documentation function 'raw)))
+    (when docstr
+      (doctest--docstring-tests docstr))))
 
 (defun doctest--feature-functions (feature)
   (let (funcs)
@@ -97,22 +105,21 @@
              for i from 1
              for progress = (format "[%d/%d]" i total)
              do
-             (pcase test
-               (`(,expr . ,want)
-                (pcase (doctest--eval expr)
-                  (`(nil ,got)
-                   (cond
-                    ((equal got want)
-                     (push test passed)
-                     (message "%s %s pass" progress (car expr)))
-                    (t
-                     (let ((print-quoted t))
-                       (message "%s %s got: %s want: %s" progress expr got want)))))
-                  (`(,err ,_)
-                   (let ((print-quoted t))
-                     (message "%s %s got error: %s"
-                              progress
-                              expr (error-message-string err))))))))
+             (cl-destructuring-bind (expr msg want) test
+               (pcase (doctest--eval expr)
+                 (`(nil ,got)
+                  (cond
+                   ((equal got want)
+                    (push test passed)
+                    (message "%s %s pass" progress (car expr)))
+                   (t
+                    (let ((print-quoted t))
+                      (message "%s %s got: %s want: %s" progress expr got want)))))
+                 (`(,err ,_)
+                  (let ((print-quoted t))
+                    (message "%s %s got error: %s"
+                             progress
+                             expr (error-message-string err)))))))
     (message "Total: %d, Pass: %d, Fail: %d"
              total (length passed) (- total (length passed)))
     (list    total (length passed) (- total (length passed)))))

--- a/doctest.el
+++ b/doctest.el
@@ -60,8 +60,7 @@
 
 (defun doctest--next-doctest ()
   (when (search-forward-regexp doctest--rex nil t)
-    (mapcar (lambda (group)
-              ((match-string-no-properties '(1 2 3))))
+    (--map (-some-> it match-string-no-properties read-from-string) '(1 2 3))))
 
 (defun doctest--collect-while-true (f)
   "Call function F and collect its results while it returns a non-NIL value"

--- a/doctest.el
+++ b/doctest.el
@@ -124,6 +124,7 @@ NOP if there is no match).
 
 If the pointer is not on a valid sexp, move forward one line and return NIL."
   (let ((sexp (condition-case e (read (current-buffer))
+                (ignore e)
                 (invalid-read-syntax nil))))
     (forward-line)
     sexp))

--- a/doctest.el
+++ b/doctest.el
@@ -28,6 +28,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'dash)
 (require 'loadhist)
 
 ;; NOT used in code, for testing
@@ -77,10 +78,7 @@
 
 (defun doctest--function-tests (function)
   "Return tests in FUNCTION's docstring."
-  ;; this is dash’s -some-> in a nutshell
-  (let ((docstr (documentation function 'raw)))
-    (when docstr
-      (doctest--docstring-tests docstr))))
+  (-some-> (documentation function 'raw) doctest--docstring-tests))
 
 (defun doctest--feature-functions (feature)
   (let (funcs)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S sh -e
+#!/usr/bin/env -S sh -e -x
 
 # Mostly copied from
 # https://github.com/purcell/package-lint/blob/f16b8a131ff8443606b472aab4cefccb6ed66986/run-tests.sh
@@ -20,8 +20,12 @@ emacs -Q -batch --eval "$INIT_PACKAGE_EL"
 
 
 # Byte compile
-emacs -Q --batch -L . --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile doctest.el
+emacs -Q --batch \
+	  --eval "$INIT_PACKAGE_EL" \
+	  -L . --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile doctest.el
 
 
 # Run doctests
-emacs -Q --batch -L . -l doctest f doctest-batch-check-feature doctest
+emacs -Q --batch \
+	  --eval "$INIT_PACKAGE_EL" \
+	  -L . -l doctest f doctest-batch-check-feature doctest

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh -e
+#!/usr/bin/env -S sh -e
 
 # Mostly copied from
 # https://github.com/purcell/package-lint/blob/f16b8a131ff8443606b472aab4cefccb6ed66986/run-tests.sh

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,4 +28,4 @@ emacs -Q --batch \
 # Run doctests
 emacs -Q --batch \
 	  --eval "$INIT_PACKAGE_EL" \
-	  -L . -l doctest f doctest-batch-check-feature doctest
+	  -L . -l doctest -f doctest-batch-check-feature doctest

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh -e
+
+# Mostly copied from
+# https://github.com/purcell/package-lint/blob/f16b8a131ff8443606b472aab4cefccb6ed66986/run-tests.sh
+
+NEEDED_PACKAGES="cl-lib dash"
+
+INIT_PACKAGE_EL="(progn \
+  (require 'package) \
+  (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives) \
+  (package-initialize) \
+  (unless package-archive-contents \
+     (package-refresh-contents)) \
+  (dolist (pkg '(${NEEDED_PACKAGES})) \
+    (unless (package-installed-p pkg) \
+      (package-install pkg))))"
+
+# Install packages
+emacs -Q -batch --eval "$INIT_PACKAGE_EL"
+
+
+# Byte compile
+emacs -Q --batch -L . --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile doctest.el
+
+
+# Run doctests
+emacs -Q --batch -L . -l doctest f doctest-batch-check-feature doctest


### PR DESCRIPTION
Updates the syntax to reflect CLHS:

- sexps are top level
- message output is captured using `->`
- test blocks can span multiple lines

README updated, tests updated to install the newly required library "dash".